### PR TITLE
Add support for HTTPs in dev and production via nginx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **npm-debug.log
 
 **.env*
+**.pem*
 
 /client/node_modules/
 

--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,16 @@ https:
 
 # Run NGINX container in daemon mode
 # KNOWN ISSUE: Docker for Mac/Windows runs in VM --network host will not work as expected
+# Replace --network host with -p 80:80 and -p 443:443 when in development
 .PHONY: nginx
 nginx:
 	docker run -d --rm \
 		--name bumper_nginx \
-		-v $(PWD)/web:/usr/share/nginx/html \
 		-v $(PWD)/config/nginx.conf:/etc/nginx/nginx.conf \
 		-v $(PWD)/config/cert.pem:/etc/nginx/ssl/nginx.crt \
 		-v $(PWD)/config/key.pem:/etc/nginx/ssl/nginx.key \
-		# -p 80:80 \ # Development setting
-		--network host \ # Production setting
+		-p 80:80 \
+		-p 443:443 \
 		nginx:alpine
 
 # Build and run Bumper in daemon mode

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,58 @@
+user nginx;
+
+worker_processes auto;
+worker_rlimit_nofile 8192;
+
+events {
+    worker_connections 8000;
+    multi_accept on;
+    use epoll;
+}
+
+error_log /var/log/nginx/error.log warn;
+
+pid /var/run/nginx.pid;
+
+http {
+    gzip on;
+    gzip_http_version 1.0;
+    gzip_comp_level 5;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types
+        application/atom+xml
+        application/javascript
+        application/json
+        application/rss+xml
+        application/vnd.ms-fontobject
+        application/x-font-ttf
+        application/x-web-app-manifest+json
+        application/xhtml+xml
+        application/xml
+        font/opentype
+        image/svg+xml
+        image/x-icon
+        text/css
+        text/plain
+        text/x-component;
+
+    server {
+        root /usr/share/nginx/html;
+
+        listen 80;
+        listen [::]:80;
+
+        listen 443 ssl;
+
+        server_name localhost;
+        ssl_certificate /etc/nginx/ssl/nginx.crt;
+        ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
+        # KNOWN ISSUE - Docker for Mac/Windows runs in VM
+        # Change localhost below to your machine's IP
+        location / {
+            proxy_pass http://localhost:9090/;
+        }
+    }
+}

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -49,7 +49,7 @@ http {
         ssl_certificate /etc/nginx/ssl/nginx.crt;
         ssl_certificate_key /etc/nginx/ssl/nginx.key;
 
-        # KNOWN ISSUE - Docker for Mac/Windows runs in VM
+        # KNOWN ISSUE - Docker for Mac/Windows runs in VM --network host will not work as expected
         # Change localhost below to your machine's IP
         location / {
             proxy_pass http://localhost:9090/;


### PR DESCRIPTION
:tickets: **Ticket(s)**: Closes #

---

## :construction_worker: Changes

* Add command to generate self-signed certificate and key
* Add command to start nginx container - mounts config and keys

## :flashlight: Testing Instructions

Generate keys with `make https`, modify the `make nginx` and `nginx.conf` according to the comments for development. Test run the server `PORT=9090 go run main.go` and go to `http://localhost/start` and `https://localhost/start` to confirm the setup works.
